### PR TITLE
Attempt to fix arrow 10.0.0 compilation on macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,8 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
+      "cflags!": [ "-fno-exceptions", "-fno-rtti" ],
+      "cflags_cc!": [ "-fno-exceptions", "-fno-rtti" ],
       "cflags_cc": [
         "<!@(pkg-config --cflags parquet arrow)", "-Wall", "-g", "-std=c++17", "-fexceptions", "-frtti" ],
       "cflags": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,11 +8,10 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
-      "cflags!": [ "-fno-exceptions", "-fno-rtti" ],
-      "cflags_cc!": [ "-fno-exceptions", "-fno-rtti" ],
-      "cflags_cc": [ "-std=c++17", "-fexceptions", "-frtti" ],
+      "cflags_cc": [
+        "<!@(pkg-config --cflags parquet arrow)", "-Wall", "-g", "-std=c++17", "-fexceptions", "-frtti" ],
       "cflags": [
-          "<!@(pkg-config --cflags parquet arrow) -Wall -g",
+        "<!@(pkg-config --cflags parquet arrow) -Wall -g",
       ],
       "ldflags": [
           "-Wl,-no-as-needed",
@@ -29,8 +28,8 @@
                   "PLATFORM_MAC=1",
               ],
               "xcode_settings": {
-                  "OTHER_CFLAGS": [
-                      "<!@(pkg-config --cflags parquet arrow) -std=c++17 -fexceptions -frtti",
+                  "OTHER_CPLUSPLUSFLAGS": [
+                    "<!@(pkg-config --cflags parquet arrow)", "-std=c++17", "-fexceptions", "-frtti"
                   ],
                   "OTHER_LDFLAGS": [
                       "<!@(pkg-config --libs parquet arrow) -lpthread",

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,7 +9,7 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "cflags!": [ "-fno-exceptions", "-fno-rtti" ],
-      "cflags_cc!": [ "-fno-exceptions", "-fno-rtti" ],
+      "cflags_cc!": [ "-std=gnu++17", "-fno-exceptions", "-fno-rtti" ],
       "cflags_cc": [
         "<!@(pkg-config --cflags parquet arrow)", "-Wall", "-g", "-std=c++17", "-fexceptions", "-frtti" ],
       "cflags": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,8 +8,12 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
-      "cflags!": [ "-fno-exceptions", "-fno-rtti" ],
-      "cflags_cc!": [ "-std=gnu++17", "-fno-exceptions", "-fno-rtti" ],
+      "cflags!": [
+        "-fno-exceptions", "-fno-rtti"
+      ],
+      "cflags_cc!": [
+        "-std=gnu++17", "-fno-exceptions", "-fno-rtti"
+      ],
       "cflags_cc": [
         "-std=c++17", "-fexceptions", "-frtti"
       ],
@@ -17,38 +21,44 @@
         "<!@(pkg-config --cflags parquet arrow) -Wall -g",
       ],
       "ldflags": [
-          "-Wl,-no-as-needed",
-          "<!@(pkg-config --libs parquet arrow) -lpthread",
+        "-Wl,-no-as-needed",
+        "<!@(pkg-config --libs parquet arrow) -lpthread",
       ],
       "conditions": [
-          ['OS == "linux"', {
-              "defines": [
-                  "PLATFORM_LINUX=1",
-              ]
-          }],
-          ['OS == "mac"', {
-              "defines": [
-                  "PLATFORM_MAC=1",
+        [
+          'OS == "linux"', {
+            "defines": [
+              "PLATFORM_LINUX=1",
+            ]
+          }
+        ],
+        [
+          'OS == "mac"', {
+            "defines": [
+              "PLATFORM_MAC=1",
+            ],
+            "xcode_settings": {
+              "OTHER_CPLUSPLUSFLAGS": [
+                "<!@(pkg-config --cflags parquet arrow)", "-std=c++17", "-fexceptions", "-frtti"
               ],
-              "xcode_settings": {
-                  "OTHER_CPLUSPLUSFLAGS": [
-                    "<!@(pkg-config --cflags parquet arrow)", "-std=c++17", "-fexceptions", "-frtti"
-                  ],
-                  "OTHER_LDFLAGS": [
-                      "<!@(pkg-config --libs parquet arrow) -lpthread",
-                  ]
-              },
-          }],
-          ['OS == "win"', {
-              "defines": [
-                  "PLATFORM_WIN=1",
-              ],
-              "include_dirs": [
-                  "include",
-                  # "/msys64/mingw64/include/gobject-introspection-1.0",
-                  # "/msys64/mingw64/lib/libffi-3.2.1/include",
+              "OTHER_LDFLAGS": [
+                "<!@(pkg-config --libs parquet arrow) -lpthread",
               ]
-          }]
+            },
+          }
+        ],
+        [
+          'OS == "win"', {
+            "defines": [
+              "PLATFORM_WIN=1",
+            ],
+            "include_dirs": [
+              "include",
+              # "/msys64/mingw64/include/gobject-introspection-1.0",
+              # "/msys64/mingw64/lib/libffi-3.2.1/include",
+            ]
+          }
+        ]
       ]
     }
   ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,8 @@
       "cflags!": [ "-fno-exceptions", "-fno-rtti" ],
       "cflags_cc!": [ "-std=gnu++17", "-fno-exceptions", "-fno-rtti" ],
       "cflags_cc": [
-        "<!@(pkg-config --cflags parquet arrow)", "-Wall", "-g", "-std=c++17", "-fexceptions", "-frtti" ],
+        "-std=c++17", "-fexceptions", "-frtti"
+      ],
       "cflags": [
         "<!@(pkg-config --cflags parquet arrow) -Wall -g",
       ],


### PR DESCRIPTION
Gets rid of `cflags!` and `cflags_cc!` (what did these even do?) and moves XCode extra flags to `OTHER_CPLUSPLUSFLAGS`